### PR TITLE
Use direct file streaming instead of presigned url

### DIFF
--- a/app/api/resume/route.js
+++ b/app/api/resume/route.js
@@ -1,5 +1,5 @@
-import { NextResponse } from 'next/server';
-import { getS3SignedUrl } from '@/lib/api/';
+import {NextResponse} from 'next/server';
+import {getS3SignedUrl} from '@/lib/api/';
 
 export async function GET() {
   try {
@@ -12,7 +12,6 @@ export async function GET() {
       },
     });
   } catch (error) {
-    return new NextResponse('Failed to load resume', { status: 500 });
+    return new NextResponse('Failed to load resume', {status: 500});
   }
 }
-

--- a/app/api/resume/route.js
+++ b/app/api/resume/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getS3SignedUrl } from '@/lib/api/';
+
+export async function GET() {
+  try {
+    const fileStream = await getS3SignedUrl(process.env.RESUME_FILE_NAME);
+
+    return new NextResponse(fileStream, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'inline; filename="resume.pdf"',
+      },
+    });
+  } catch (error) {
+    return new NextResponse('Failed to load resume', { status: 500 });
+  }
+}
+

--- a/app/resume/page.js
+++ b/app/resume/page.js
@@ -1,22 +1,12 @@
-export const revalidate = 60 * 60; // Revalidate every hour
-
-import {getS3SignedUrl} from '@/lib/api';
-
-export default async function Resume() {
-  const resumeUrl = await getS3SignedUrl(process.env.RESUME_FILE_NAME);
-
+export default function Resume() {
   return (
     <main className="h-full">
-      {resumeUrl ? (
-        <iframe
-          title="Natasha Osborne's Resume"
-          alt="Natasha Osborne's Resume"
-          className="h-full w-full"
-          src={resumeUrl}
-        />
-      ) : (
-        <p>Loading image...</p>
-      )}
+      <iframe
+        title="Natasha Osborne's Resume"
+        alt="Natasha Osborne's Resume"
+        className="h-full w-full"
+        src="/api/resume"
+      />
     </main>
   );
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -43,8 +43,8 @@ export async function getS3SignedUrl(key) {
       Key: key,
     });
 
-    const url = await getSignedUrl(s3, command, {expiresIn: 60 * 60});
-    return url;
+    const response = await s3.send(command);
+    return response.Body;
   } catch (error) {
     console.error('Error fetching object from S3:', error);
     return new Response('Error fetching object from S3', error);

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import matter from 'gray-matter';
 import {join} from 'path';
 import {GetObjectCommand, S3Client} from '@aws-sdk/client-s3';
-import {getSignedUrl} from '@aws-sdk/s3-request-presigner';
 
 const postsDirectory = join(process.cwd(), '_posts');
 


### PR DESCRIPTION
### What does this PR do?
- Move away from the pre-signed url. There is not enough traffic to revalidate the url regularly, leading to an error page, and there is an issue with the pre-signed url being leaked. So instead I'm going to move to direct file streaming.

### Performance Testing
For the current traffic, this strategy is fine. In a story in the very near future, I'll implement Amazon Cloudfront or look into Vercel options if they exist.
