### PR TITLE
extract section header for consistent styling

### DIFF
--- a/app/components/about.js
+++ b/app/components/about.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import {UserIcon} from '@heroicons/react/24/outline';
 
 import useObserver from './use-observer';
+import SectionHeader from './section-header';
 
 export default function About() {
   const aboutRef = useRef(null);
@@ -10,16 +11,11 @@ export default function About() {
 
   return (
     <main ref={aboutRef} className="main-container overflow-hidden">
-      <div className="w-screen  lg:max-w-lg xl:max-w-xl max-w-2xl content">
-        <header className="relative z-10 pl-6 flex flex-row items-center">
-          <UserIcon className="h-7 w-7 lg:h-8 lg:w-8 text-gray-500 hover:fill-[#d4af37] lg:mr-2" />
-          <span className="pl-2 flex items-center text-lg font-medium text-[#f5f5f5]">
-            About
-          </span>
-        </header>
+      <div className="w-screen lg:max-w-lg xl:max-w-xl max-w-2xl content">
+        <SectionHeader Icon={UserIcon} text="About" />
 
         <div className="relative z-10">
-          <div className="p-4 md:p-6 lg:py-12 2xl:py-0 space-y-4 text-wrap leading-loose 2xl:leading-relaxed">
+          <div className="p-4 md:p-6 2xl:py-0 space-y-4 text-wrap leading-loose 2xl:leading-relaxed">
             <p>
               In 2016, I built an Excel spreadsheet that evolved into a PHP app
               to track my workouts. I obtained my first gig as a software

--- a/app/components/projects.js
+++ b/app/components/projects.js
@@ -4,6 +4,7 @@ import {FolderOpenIcon} from '@heroicons/react/24/outline';
 import {ArrowTopRightOnSquareIcon} from '@heroicons/react/20/solid';
 
 import SkillBubble from './skill-bubble';
+import SectionHeader from './section-header';
 
 const projects = [
   {
@@ -35,12 +36,8 @@ const projects = [
 const ProjectsPage = () => {
   return (
     <main className="main-container lg:pt-20 relative">
-      <header className="relative z-10 pl-6 pb-10 flex flex-row items-center">
-        <FolderOpenIcon className="h-7 w-7 lg:h-8 lg:w-8 text-gray-500 hover:fill-[#d4af37] lg:mr-2" />
-        <span className="pl-2 flex items-center text-lg font-medium text-[#f5f5f5]">
-          Featured Projects
-        </span>
-      </header>
+      <SectionHeader Icon={FolderOpenIcon} text="Featured Projects" />
+
       <div className="p-6 flex items-center">
         <div className="grid grid-cols-1 gap-6 z-10 list-none">
           {projects.map((project, index) => (

--- a/app/components/resume-timeline.js
+++ b/app/components/resume-timeline.js
@@ -6,6 +6,7 @@ import {ArrowTopRightOnSquareIcon} from '@heroicons/react/20/solid';
 import {DocumentTextIcon} from '@heroicons/react/24/outline';
 
 import SkillBubble from './skill-bubble';
+import SectionHeader from './section-header';
 import useObserver from './use-observer';
 import technologies from '@/lib/data/technologies.json';
 
@@ -58,10 +59,7 @@ const ResumeTimeline = () => {
   return (
     <div ref={timelineRef} className="timeline main-container">
       <div className="content group">
-        <header className="relative z-10 flex flex-row items-center pl-6 pb-12">
-          <DocumentTextIcon className="h-7 w-7 lg:h-8 lg:w-8 text-gray-500 hover:fill-[#d4af37] lg:mr-2" />
-          <span className="pl-2 flex items-center">Resume</span>
-        </header>
+        <SectionHeader Icon={DocumentTextIcon} text="Resume" />
 
         <TimelineItem
           href="/resume"

--- a/app/components/section-header.js
+++ b/app/components/section-header.js
@@ -1,0 +1,10 @@
+const SectionHeader = ({Icon, text}) => (
+  <header className="relative z-10 pl-6 pb-10 flex flex-row items-center">
+    <Icon className="h-7 w-7 lg:h-8 lg:w-8 text-gray-500 hover:fill-[#d4af37] lg:mr-2" />
+    <span className="pl-2 flex items-center text-lg font-medium text-[#f5f5f5]">
+      {text}
+    </span>
+  </header>
+);
+
+export default SectionHeader;


### PR DESCRIPTION
### What does this PR do?
- Fix inconsistent section header stying. For the about page on larger screens, the styling was bad

### Screenshots
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/5aa6f597-e967-4584-a6ef-ab8eeccf5224">

