### PR TITLE
About text styling

### DIFF
--- a/app/components/about.js
+++ b/app/components/about.js
@@ -11,7 +11,7 @@ export default function About() {
 
   return (
     <main ref={aboutRef} className="main-container overflow-hidden">
-      <div className="w-screen lg:max-w-lg xl:max-w-xl max-w-2xl content">
+      <div className="lg:max-w-lg xl:max-w-xl max-w-2xl content">
         <SectionHeader Icon={UserIcon} text="About" />
 
         <div className="relative z-10">

--- a/app/components/about.js
+++ b/app/components/about.js
@@ -15,7 +15,7 @@ export default function About() {
         <SectionHeader Icon={UserIcon} text="About" />
 
         <div className="relative z-10">
-          <div className="p-4 md:p-6 2xl:py-0 space-y-4 text-wrap leading-loose 2xl:leading-relaxed">
+          <div className="p-6 2xl:py-0 space-y-4 text-wrap leading-loose 2xl:leading-relaxed">
             <p>
               In 2016, I built an Excel spreadsheet that evolved into a PHP app
               to track my workouts. I obtained my first gig as a software

--- a/app/page.js
+++ b/app/page.js
@@ -27,7 +27,7 @@ export default function Main() {
       />
       <div className="lg:col-span-1"></div>
       <main className="lg:col-span-1">
-        <div className="ml-4 md:ml-16 2xl:ml-48">
+        <div className="ml-4 md:ml-16 lg:m-0 2xl:ml-48">
           {PAGES.map((page, index) => {
             const Component = SCROLL_COMPONENTS.find(
               (c) => c.id === page.id,


### PR DESCRIPTION
### What does this PR do?
Fix styling issues around about text
- From 1024px to 1120px, the about text was clipped on the right side
- the about icon was positioned too far to the right on mobile screen sizes
- the about text didn't have enough padding on the right side on mobile screen sizes

### Screenshots

#### Before
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/dca9320e-e5e3-4655-86fd-b7f7dca4e7da">
<img width="299" alt="image" src="https://github.com/user-attachments/assets/7da65497-8cfc-4f53-b3b5-a06178683997">


#### After
<img width="299" alt="image" src="https://github.com/user-attachments/assets/31937753-db8b-4ab5-96f6-2f958aedc71b">
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/166565ed-17b2-4311-bfd7-97346691258b">


### Responsiveness Testing
Tested on:
  - Pixel 6
  - 13 " Macbook pro (with resizing)
  - windows desktop monitor (with resizing)